### PR TITLE
Readme and URL updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,43 @@
-# Steam Tinker Launch
-[![GitHub version](https://img.shields.io/github/v/tag/sonic2kk/steamtinkerlaunch?label=version&style=flat-square)](https://github.com/sonic2kk/steamtinkerlaunch/releases/latest)
-[![GitHub stars](https://img.shields.io/github/stars/sonic2kk/steamtinkerlaunch.svg?style=flat-square)](https://github.com/sonic2kk/steamtinkerlaunch/stargazers)
-![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/sonic2kk/steamtinkerlaunch?style=flat-square)
-[![GitHub contributors](https://img.shields.io/github/contributors/sonic2kk/steamtinkerlaunch.svg?style=flat-square)](https://github.com/sonic2kk/steamtinkerlaunch/graphs/contributors)
-[![aur votes](https://img.shields.io/aur/votes/steamtinkerlaunch?label=aur%20votes&style=flat-square)](https://aur.archlinux.org/packages/steamtinkerlaunch)
-[![GitHub issues](https://img.shields.io/github/issues/sonic2kk/steamtinkerlaunch.svg?style=flat-square)](https://github.com/sonic2kk/steamtinkerlaunch/issues)
-[![GitHub license](https://img.shields.io/github/license/sonic2kk/steamtinkerlaunch.svg?style=flat-square)](https://github.com/sonic2kk/steamtinkerlaunch/blob/dev/LICENSE)
+# Steam Tinker Launch (cegc fork)
+[![GitHub version](https://img.shields.io/github/v/tag/daailouivan/steamtinkerlaunch?label=version&style=flat-square)](https://github.com/daailouivan/steamtinkerlaunch/releases/latest)
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/daailouivan/steamtinkerlaunch?style=flat-square)
+[![GitHub license](https://img.shields.io/github/license/daailouivan/steamtinkerlaunch.svg?style=flat-square)](https://github.com/daailouivan/steamtinkerlaunch/blob/dev/LICENSE)
 
-## What is SteamTinkerLaunch?
+## Overview
+This is an **unofficial** fork of [SteamTinkerLaunch](https://github.com/sonic2kk/steamtinkerlaunch) which reimplements support for GameConqueror and CheatEngine with newer SteamTinkerLaunch versions.
 
-<img align="left" width="64" height="64" src="https://github.com/frostworx/repo-assets/blob/master/pics/steamtinkerlaunch-logo_64px.png" alt="**SteamTinkerLaunch** is a Linux wrapper tool for use with the Steam client">
+These tools were removed from SteamTinkerLaunch v12.0 and later following concerns that invasive anti-cheat programs such as Easy Anti-Cheat would permanently ban users who have these tools or any reference to these tools on their system, following their behaviour on Windows.
 
-**Steam Tinker Launch** is a versatile Linux wrapper tool for use with the Steam client which allows for easy graphical configuration of game tools, such as [GameScope](https://github.com/sonic2kk/steamtinkerlaunch/wiki/GameScope), [MangoHud](https://github.com/sonic2kk/steamtinkerlaunch/wiki/MangoHud), [modding tools](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Modding) and a bunch more. It supports both games using Proton and native Linux games, and works on both X11 and Wayland.
- 
-As described by _/u/TaylorRoyal23_ on [r/linux_gaming](https://www.reddit.com/r/linux_gaming/comments/ud58i2/comment/i6i3yf9/?utm_source=share&utm_medium=web2x&context=3):
+For more background on why these tools were removed, see the [SteamTinkerLaunch FAQ](https://github.com/sonic2kk/steamtinkerlaunch/wiki/FAQ#where-did-cheat-enginegameconqueror-go).
 
-> _"An incredible wrapper with a menu that lets you easily toggle and modify various settings for games on Linux.
-Anything from proton versions, to startup and exit scripts, proton/dxvk/etc. settings, FSR, reshade,
-and even options for various tools like gamemode, replay-sorcery, gamescope, etc. Tons more too.
-I just set my default proton version to "steam tinker launcher" and then every game launches
-with a 2 second menu that allows you to easily change any of the settings.
-If you don't press any buttons it just goes with the defaults and launches the game.
-The menus can get a little confusing but it consolidates it all in one place and is way more simple
-than trying to remember dozens of commands for various settings that one might need."_
+Issues encountered when using this fork should **not** be reported on the official SteamTinkerLaunch repository.
 
-![Main Menu](https://user-images.githubusercontent.com/7917345/231897862-401c8702-af1b-4a51-9ace-8a3f04ca2cf2.png)
+## Usage
+Using SteamTinkerLaunch as a [compatibility tool](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Compatibility-Tool) is the intended way of using it with Proton games, which are the primary type of game supported by cheat tools. Once SteamTinkerLaunch is installed, force it as a compatibility tool for your chosen game from the list of compatibility tools. You can also set SteamTinkerLaunch as the default compatibility tool for all applications from the Steam Play settings of the Steam client. Keep in mind that if you force SteamTinkerLaunch as a compatibility tool, Steam will always download the Windows release of the game.
 
-## What Does It Do?
-SteamTinkerLaunch offers a huge variety of features, too many to list in this Readme. Please see the [Features List](https://github.com/sonic2kk/steamtinkerlaunch/wiki#features) and their associated wiki pages for a full breakdown. However, here are some of the key features offered by SteamTinkerLaunch. Note that some of these features may not work with Flatpak Steam!
+You can also use SteamTinkerLaunch with native Linux games by adding `steamtinkerlaunch %command%` to the game's launch options. Keep in mind that cheat tool support for native Linux games may be limited.
 
-| Feature | Description |
-| ------- | ----------- |
-| Custom Per-Game Environment Variables | Set custom environment variables on a per-game basis. Useful for adding command-line tweaks for various games. |
-| Custom Game Executable | Change the executable that Steam launches. Useful for custom game launchers/mod launchers.<br /><br />This option is extremely flexible, allowing for launching a custom executable with a game, instead of the game, before the game or after the game. See the [Custom Program wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Custom-Command) for usage. |
-| Easy installation of Winetricks verbs | SteamTinkerLaunch can apply the necessary steps to install, for example, `dotnet48` or later in a Proton prefix, which can fix common issues with GUI tools running through Proton.<br /><br />It is **highly recommended** to install `dotnet48` using a community flavour of Proton such as GE-Proton or Proton 5.0. You will also want to ensure your Winetricks version is up-to-date. |
-| [ModOrganizer 2](https://github.com/ModOrganizer2/modorganizer) Support | Installs and sets up mod installation and organization tool ModOrganizer 2. Includes browser and command line integration for handling NXM links with `xdg-open`.<br /><br />See our [ModOrganizer 2 wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Mod-Organizer-2) and [modding wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Modding) for more details. |
-| [Vortex Mod Manager](https://www.nexusmods.com/about/vortex/) Support | Installs and sets up Nexus Mods' mod management tool Vortex Mod Manager. Includes browser and command line integration for handling NXM links with `xdg-open`.<br /><br />See our [Vortex wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Vortex) and [modding wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Modding) for more details. |
-| [SpecialK](https://github.com/SpecialKO) Support | Utility for enhancing and fixing common problems with Windows games.<br /><br />See our [SpecialK wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/SpecialK) for usage. May require additional [Optional Dependencies](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#optional-dependencies). |
-| [ReShade](https://reshade.me/) Support (Proton/Wine Only) | Supports the use of ReShade shaders to enhance the visual quality of Windows games. Note that ReShade does not support native Linux games.<br /><br />See our [ReShade wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/ReShade) for usage and information on using **ReShade** and **SpecialK** together. |
-| [Hedge Mod Manager](https://github.com/thesupersonic16/HedgeModManager) support | Supports automatic installation of the Open-Source Modern Sonic game mod manager as well as attempting to install workarounds for various games that require it.<br/><br/>Due to the nature of this tweaks relying on Winetricks some manual intervention may be required in some instances. Please see the [SteamTinkerLaunch Hedge Mod Manager wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Hedge-Mod-Manager) for details. |
-| Custom Wine/Proton Download | Manages downloading custom Proton and Wine releases, such as GloriousEggroll's popular Proton flavour [GEProton](https://github.com/GloriousEggroll/proton-ge-custom). These versions are installed and managed by SteamTinkerLaunch. (**Requires `jq` to be installed!**)<br /><br />See our wiki pages on [Custom Proton Versions](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Download-Custom-Proton) and [Custom Wine Versions](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Download-Custom-Wine) for more details. |
+## Command Line
+SteamTinkerLaunch has several [command line options](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Command-Line) which can be useful outside Steam, such as for installing modding tools. You can run `steamtinkerlaunch help` for a full list of available commands.
 
-To find out about the latest release, check out the [stable release changelog](https://github.com/sonic2kk/steamtinkerlaunch/releases/latest). To find out about the latest bleeding-edge development changes not yet in a stable build, check out the [full changelog](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Changelog).
+## Installation
+This fork of SteamTinkerLaunch should be installed manually. You can grab it from git or from the [releases page](https://github.com/daailouivan/steamtinkerlaunch/releases).
 
-## How Do I Use It?
-### General usage
-Steam Tinker Launch works with Linux native games and games using Proton, however some Windows-only utilities (such as [ReShade](https://github.com/sonic2kk/steamtinkerlaunch/wiki/ReShade)) are only available for Proton games. SteamTinkerLaunch also supports Non-Steam Games so long as they are launched through the Steam client.
+### Dependencies
+The general SteamTinkerLaunch [manual installation steps](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#manual-installation) should mostly apply. You must still ensure you have the relevant hard dependencies installed.
 
-There are two ways to use SteamTinkerLaunch through Steam, either as a Compatibility Tool (intended for Proton games) or as a Launch Option (intended for native Linux games). Only **one** of these options should be used per game.
-
-#### Steam Compatibility Tool (**Proton Games**)
-Using SteamTinkerLaunch as a [compatibility tool](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Compatibility-Tool) is the intended way of using it with Proton games. Once SteamTinkerLaunch is installed, force it as a compatibility tool for your chosen game from the list of compatibility tools. You can also set SteamTinkerLaunch as the default compatibility tool for all applications from the Steam Play settings of the Steam client. Keep in mind that if you force SteamTinkerLaunch as a compatibility tool, Steam will always download the Windows release of the game.
-
-#### Steam Launch Option (**Native Linux Games**)
-Using SteamTinkerLaunch as a [Launch Option](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Launch-Option) is the intended way of using it with native Linux games. You can enable SteamTinkerLaunch as a launch option
-
-```sh
-steamtinkerlaunch %command%
-```
-
-On some platforms such as [Steam Deck](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Deck), using SteamTinkerLaunch as a launch option may require you to add it to your path. Refer to your distributions documentation on how to add the script to your path, as this can vary between distributions and shells. If you installed SteamTinkerLaunch via [ProtonUp-Qt](https://github.com/sonic2kk/steamtinkerlaunch/wiki/ProtonUp-Qt) it will added to your path for you, though you may still have to set the path to `$HOME/stl/prefix/steamtinkerlaunch` as described on the [Launch Option wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Launch-Option).
-
-It is possible to use SteamTinkerLaunch as a launch option for Proton games, but this is **not** the intended use-case.
-
-### Game-Specific Use
-When starting a game, a small [Wait Requester](#Wait-Requester) dialog will pop up. This will allow you to access the Main Menu either by pressing the button or pressing the spacebar, or skip to launching the game. By default, the dialog will only stay for two seconds before it times out and launches the game, but this can be configured in the SteamTinkerLaunch settings.
-
-![Wait Requester](https://user-images.githubusercontent.com/7917345/231898092-86a0441e-c82e-4ec1-aff1-15de236fbf56.png)
-
-The Main Menu is the springboard to tinkering with your game options. See the [wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Main-Menu) for more information on the options it provides. 
-
-### Command Line
-SteamTinkerLaunch has several [command line options](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Command-Line) which can be useful outside Steam, such as for installing modding tools. You can run `steamtinkerlaunch help` for a full list of available commands, or if SteamTinkerLaunch is not in your path you can run `sh steamtinkerlaunch help` from the folder where you downloaded SteamTinkerLaunch. 
-
-## How Do I Install It?
-SteamTinkerLaunch can be installed in a few different ways depending on your platform and needs. Please refer to the [Installation wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation) for detailed installation instructions.
-
-| Platform | Notes |
-| -------- | ----- |
-| Package Manager | Preferred installation method. See distribution package status below, though this list may not be exhaustive.<br />Many thanks to all package maintainers!<br /><br />[![Packaging status](https://repology.org/badge/vertical-allrepos/steamtinkerlaunch.svg)](https://repology.org/project/steamtinkerlaunch/versions)<br /><br />Refer to the [Installation Wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#package-manager) for more information on available packages. |
-| [ProtonUp-Qt](https://github.com/sonic2kk/steamtinkerlaunch/wiki/ProtonUp-Qt) | As of v2.7.3, [ProtonUp-Qt](https://github.com/DavidoTek/ProtonUp-Qt) has support for SteamTinkerLaunch. This should allow you to intall SteamTinkerLaunch regardless which distribution you are using **including Steam Deck**. See the [Installation wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#protonup-qt) and our [ProtonUp-Qt wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/ProtonUp-Qt) for more details.<br /><br />Outside of Steam Deck, ensure you have met the relevant SteamTinkerLaunch [hard dependencies](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#hard-dependencies). |
-| Manual Installation | SteamTinkerLaunch supports **system-wide** (root) and **local** (non-root) manual installation. [See Installation Wiki notes](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#manual-installation) for setup and details. |
-| [Steam Deck](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Deck) | See [Installation Wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#steam-deck) for Steam Deck specific installation instructions. |
-| [Steam Flatpak](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Flatpak) | See [Installation Wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#steam-flatpak) for setup instructions on using Steam Flatpak and SteamTinkerLaunch.<br><br>**NOTE:** This is **only** for Flatpak Steam. |
-| Other | See [Installation Wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#distro-specific) for any distro-specific installation instructions. |
-
-## Press
-Several great people have mentioned SteamTinkerLaunch on their platforms/channels. Many thanks to all who have covered SteamTinkerLaunch!
-
-| Name | Press |
-| ---- | ----- |
-| **[podiki](https://boilingsteam.com/author/podiki/)** (also a SteamTinkerLaunch contributor) | [Wrote a huge article about SteamTinkerLaunch on BoilingSteam](https://boilingsteam.com/supercharge-steam-with-steamtinkerlaunch-stl)! |
-| **[ekianjo](https://boilingsteam.com/author/ekianjo/)** | [Wrote up a Q&A on BoilingSteam](https://boilingsteam.com/steam-tinker-launcher-making-tinkering-much-easier) with SteamTinkerLaunch creator Frostworx! |
-| **[Hex DSL](https://www.youtube.com/c/HexDSL)** | Made a [YouTube video](https://www.youtube.com/watch?v=rdXQRMwMfPE) showcasing SteamTinkerLaunch |
-| **[tuxfoo](https://www.youtube.com/channel/UCWpoyqSBIXtylRLFgP3PFfg)** | Made a [YouTube video](https://www.youtube.com/watch?v=l1KjIANTIKs) showcasing SteamTinkerLaunch
-| **[Linux Game Cast](https://linuxgamecast.com/)** | Mentioned SteamTinkerLaunch on their [casts](https://www.youtube.com/watch?v=djuZdnE83fE&t=436s) [several](https://www.youtube.com/watch?v=yVsTMhx8E7c&t=983s) [times](https://www.youtube.com/watch?v=qhybhTGV3mA&t=1279s), and [counting]((https://linuxgamecast.com/2021/11/linux-game-cast-484-yami-pedro))! |
-| **[Mark Dougherty](https://linuxgamingcentral.com/)** | Has written [several](https://linuxgamingcentral.com/posts/news-stl-v10-released/) [articles](https://linuxgamingcentral.com/posts/stl-v11-released/) about SteamTinkerLaunch |
-| **[Kevin Wammer](https://overkill.wtf/author/kevin/)** | Wrote [this article](https://overkill.wtf/steam-deck-steam-tinker-launch-stl/) |
-| **[Starlogical from HiTechLoLife](https://www.youtube.com/c/HiTechLoLife)** | Created [this video](https://www.youtube.com/watch?v=4FRU2fuvLlw) describing SteamTinkerLaunch |
-| **[joker1007](https://joker1007.hatenablog.com)** (Japanese) | Wrote a [huge article](https://joker1007.hatenablog.com/entry/2022/11/28/014825) on SteamTinkerLaunch for Japanese users |
-
- 
-## Configuration
-When SteamTinkerLaunch is started for the first time, it will create its default [configuration](#Configuration) structure (usually in `~/.config/steamtinkerlaunch`). All [Configuration Files](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Configuration-Files) are self-contained documents and are always growing, and as a result some options may be missing. If you find a configuration option that is not documented, please request it on the [issue tracker](https://github.com/sonic2kk/steamtinkerlaunch/issues). You may even write the documentation yourself and a collaborator can add it.
-
-For a general overview what can be configured, you check the [wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki), or simply browse through the 
-[Main Menu](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Main-Menu), which covers almost everything available. If you want to get an overview of SteamTinkerLaunch's features, and you find the huge [wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki) too overwhelming,
-you might want to check out the [articles and videos](#Press) created by members of the community.
-
-### Configuration with Text Editors
-As mentioned, almost everything can be configured from the [Main Menu](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Main-Menu), but optionally you can edit SteamTinkerLaunch's global and per-game configuration files with a graphical text editor for a more granular approach. Before diving into editing with a text editor, it might be a good idea to start by exploring the configuration options in the [Main Menu](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Main-Menu), and then diving in and tweaking with a text editor.
-
-For more information on SteamTinkerLaunch's specific configuration files, see the [Configuration Files wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Configuration-Files).
-
-For information on where SteamTinkerLaunch stores downloaded files, see the [Downloads wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Downloads).
+As well as these, **_`innoextract` is also required_** for cheat tool functionality. You can install it from your package manager on Linux Desktop.
 
 ## Troubleshooting
 ### Logs
 Logs are written into the `LOGDIR` as defined in the [Global Menu](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Global-Menu) or [Global Config](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Configuration-Files#Global-Config) (by default, this is usually `~/.config/steamtinkerlaunch/logs/`). The verbosity of the logfile depends on the `WRITELOG` variable, where `0` is no logging, `1` is less verbosity and `2` is most verbosity.
 
-SteamTinkerLaunch produces a number of logs, including game-specific log files. For logs that have a Steam AppID in them (such as Proton logs), there is usually a symlink for the log file with the game's name to make it easier to identify logs. 
+SteamTinkerLaunch produces a number of logs, including game-specific log files. For logs that have a Steam AppID in them (such as Proton logs), there is usually a symlink for the log file with the game's name to make it easier to identify logs.
 
 SteamTinkerLaunch may also store additional logging information in `/dev/shm/steamtinkerlaunch`.
 
-As well as logs, there is a wiki page for [troubleshooting](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Troubleshooting) which lists some problems a few users have faced and some known issues.
-
 ## Disclaimer
-Keep in mind that you are using SteamTinkerLaunch at your own risk and that you are responsible for the third party programs that you launch with it. SteamTinkerLaunch is not affiliated with Valve Corporation or Steam.
-
-## Contributing
-SteamTinkerLaunch is always looking for new contributors. See [CONTRIBUTING.md](https://github.com/sonic2kk/steamtinkerlaunch/blob/master/CONTRIBUTING.md) for some more information on how to contribute to the project.
+These cheat tools (including text references to them) may cause you to be **permanently banned** in games which use invasive anti-cheat tools such as Easy Anti-Cheat or battlEye. While this fork restores the functionality it is **not** responsible if you get banned for using them.
 
 ## License
-SteamTinkerLaunch is licensed under the GNU General Public License v3.0. See [LICENSE](https://github.com/sonic2kk/steamtinkerlaunch/blob/master/LICENSE) for more information.
+SteamTinkerLaunch is licensed under the GNU General Public License v3.0. See [LICENSE](https://github.com/daailouivan/steamtinkerlaunch/blob/master/LICENSE) for more information.

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -11,7 +11,8 @@ PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
 AGHURL="https://api.github.com"
-PROJECTPAGE="$GHURL/sonic2kk/${PROGNAME,,}"
+PROJECTPAGE="$GHURL/daailouivan/${PROGNAME,,}"
+UPSTREAMPROJECTPAGE="$GHURL/sonic2kk/${PROGNAME,,}"
 PPW="$PROJECTPAGE/wiki"
 CURWIKI="$PPW"
 STARTDEBUG=1
@@ -2561,7 +2562,7 @@ function getAvailableProtonVersions {
 function setDefaultCfgValues {
 
 	function setDefaultCfgValuesurl {
-		if [ -z "$PROJECTPAGE" ]						; then	PROJECTPAGE="$GHURL/sonic2kk/steamtinkerlaunch"; fi
+		if [ -z "$PROJECTPAGE" ]						; then	PROJECTPAGE="$GHURL/daailouivan/steamtinkerlaunch"; fi
 		if [ -z "$CP_PROTONTKG" ]						; then	CP_PROTONTKG="$GHURL/Frogging-Family/wine-tkg-git"; fi
 		if [ -z "$CP_PROTONGE" ]						; then	CP_PROTONGE="$GHURL/GloriousEggroll/proton-ge-custom"; fi
 		if [ -z "$CP_PROTONSTL" ]						; then	CP_PROTONSTL="$GHURL/frostworx/steamtinkerlaunch-tweaks"; fi
@@ -16266,7 +16267,7 @@ function checkIntDeps {
 
 		if [ ! -x "$(command -v "$YAD")" ]; then
 			DEPSMISSING=1
-			writelog "ERROR" "${FUNCNAME[0]} - '$YAD' was not found! Check '${PROGCMD} --help' for alternatives and/or read '$PROJECTPAGE/wiki/Yad'" "E"
+			writelog "ERROR" "${FUNCNAME[0]} - '$YAD' was not found! Check '${PROGCMD} --help' for alternatives and/or read '$UPSTREAMPROJECTPAGE/wiki/Yad'" "E"
 			notiShow "$(strFix "$NOTY_NOTFOUND" "$YAD")"
 		fi
 


### PR DESCRIPTION
Hello!

I am the maintainer of upstream SteamTinkerLaunch. I've kept an eye on this fork for a while and noticed you recently made a release - Awesome! Before I became maintainer I also briefly considered maintaining a branch on my fork of STL that had GameConqueror and CheatEngine in-tact, but as I don't use these tools I decided against it (and then I ended up becoming maintainer afterwards). Nice to see that someone picked it up though :-)

I thought it might be a good idea to make a small code change that updates some of the URLs pointing to STL, and also an overhaul to the README, to make it clearer that this is a fork and some of the risks involved with using these cheat tools.

Before I continue, I really hope this doesn't come across poorly. This is purely for clarity for anyone that might come across this fork. The changes I have proposed here can be declined in favour of your own changes, that's totally fine. Or even still, if you don't want to make *any* changes, there'll be no hard feelings. This PR is purely a suggestion and a way of reaching out about it. I didn't see a contact email or I would've reached out that way :slightly_smiling_face: 

This is *your* fork and I have no authority to "demand" any change and that's not at all what I want to do here, so I hope it doesn't come across the wrong way.

<hr>

In short, I stripped the Readme down to the essentials needed for using this STL fork. I would imagine users coming to this fork should know how to use STL already and should simply be looking for the restored cegc functionality. The Readme now attempts to make clearer that this is an unofficial fork (in case users get confused, somehow).

Since this is being more """actively""" distributed, in that a non-technical user, who probably shouldn't be using a tinker tool in the first place, sees a release and tries to use it, I thought it would be good to make it more direct that this is not an official build of STL and that I cannot give support to users who are using it - Might seem strange but I can honestly foresee a situation where a user might report an issue with Cheat Engine to me, similar has happened in the past :sweat_smile: 

<hr>

Also as a small courtesy, I'd like to point out that for Cheat Engine, redistribution appears to be a grey area at best. It was noted in #618 that redistribution is likely against Cheat Engine's license.

<hr>

Thanks!